### PR TITLE
Updated omeka version constraint to include ^4.0.0

### DIFF
--- a/config/module.ini
+++ b/config/module.ini
@@ -1,6 +1,6 @@
 [info]
 version = "1.4.0"
-omeka_version_constraint = "^3.0.0"
+omeka_version_constraint = "^3.0.0 || ^4.0.0"
 name = "Wikidata"
 description = "Describe resources using values and URIs from Wikidata."
 author = "Nishad Thalhath"


### PR DESCRIPTION
This Pull Request updates the module.ini file for the Wikidata module for Omeka S, allowing compatibility with version ^4.0.0 and above. The change modifies the version constraint for Omeka from "^3.0.0" to "^3.0.0 || ^4.0.0", ensuring the module functions with the latest stable version of Omeka S (4.1.1). This update resolves an issue where the module could not be installed on updated systems, thereby enhancing its usability and encouraging its adoption in projects that rely on the most recent versions of Omeka S. The change does not affect the module's functionality beyond this compatibility adjustment.